### PR TITLE
Integration tests: remove dependency on RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,20 @@ Anschließend kann im Ordner `backend` das Backend folgendermaßen gebuildet, Un
 
 ## Umgebungsvariablen
 
-| Variable           | Beschreibung                         |
-|:-------------------|:-------------------------------------|
-| DATABASE\_HOST     | Hostname oder IP des MySQL Servers   |
-| DATABASE\_PORT     | Port des MySQL Servers               |
-| DATABASE           | Name der Datenbank-Instanz           |
-| DATABASE\_USER     | Benutzername                         |
-| DATABASE\_PASSWORD | Passwort des Benutzers               |
-| RABBITMQ\_HOST     | Hostname des RabbitMQ Servers        |
-| RABBITMQ\_PORT     | Port des RabbitMQ Servers            |
-| RABBITMQ\_USER     | Benutzername auf dem RabbitMQ Server |
-| RABBITMQ\_PASSWORD | Passwort des Benutzers               |
-| RABBITMQ\_EXCHANGE | Name des Topic Exchanges             |
-| MAINHUB            | Base-URL der MainHub-API             |
+| Variable           | Beschreibung                                                  |
+|:-------------------|:--------------------------------------------------------------|
+| DATABASE\_HOST     | Hostname oder IP des MySQL Servers                            |
+| DATABASE\_PORT     | Port des MySQL Servers                                        |
+| DATABASE           | Name der Datenbank-Instanz                                    |
+| DATABASE\_USER     | Benutzername                                                  |
+| DATABASE\_PASSWORD | Passwort des Benutzers                                        |
+| RABBITMQ\_HOST     | Hostname des RabbitMQ Servers                                 |
+| RABBITMQ\_PORT     | Port des RabbitMQ Servers                                     |
+| RABBITMQ\_USER     | Benutzername auf dem RabbitMQ Server                          |
+| RABBITMQ\_PASSWORD | Passwort des Benutzers                                        |
+| RABBITMQ\_EXCHANGE | Name des Topic Exchanges                                      |
+| MAINHUB            | Base-URL der MainHub-API                                      |
+| JWT_SECRET         | Secret des JWT-Tokens (nur benötigt in den Integrationstests) |
 
 # Frontend
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Zur Laufzeit wird das Frontend und das Backend benötigt.
 ## Starten
 
 Zunächst müssen die Umgebungsvariablen (siehe unten) gesetzt werden. 
-Anschließend kann im Ordner `test/cypress` die Integrationstests folgendermaßen gestartet werden:
+Anschließend kann im Ordner `frontend` die Integrationstests folgendermaßen gestartet werden:
 ```
 npm run cypress:run
 ```

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -48,3 +48,13 @@ allOpen {
 	annotation("javax.persistence.MappedSuperclass")
 	annotation("javax.persistence.Embeddable")
 }
+
+if (project.hasProperty("isIntegrationTest")) {
+	tasks.withType<KotlinCompile> {
+		exclude("com/smartcity/education/backend/RabbitMqConfig.kt")
+	}
+} else {
+	tasks.withType<KotlinCompile> {
+		exclude("com/smartcity/education/backend/TestJwtConfig.kt")
+	}
+}

--- a/backend/src/main/kotlin/com/smartcity/education/backend/MessageSender.kt
+++ b/backend/src/main/kotlin/com/smartcity/education/backend/MessageSender.kt
@@ -1,0 +1,5 @@
+package com.smartcity.education.backend
+
+fun interface MessageSender {
+    fun send(routingKey: String, payload: Any)
+}

--- a/backend/src/main/kotlin/com/smartcity/education/backend/RabbitMqConfig.kt
+++ b/backend/src/main/kotlin/com/smartcity/education/backend/RabbitMqConfig.kt
@@ -49,10 +49,16 @@ class RabbitMqConfig {
     }
 
     @Bean
-    fun sendHello(template: RabbitTemplate): ApplicationRunner {
+    fun messageSender(template: RabbitTemplate): MessageSender {
+        return MessageSender { routingKey, payload ->
+            template.convertAndSend(Constants.exchange, routingKey, payload)
+        }
+    }
+
+    @Bean
+    fun sendHello(sender: MessageSender): ApplicationRunner {
         return ApplicationRunner {
-            template.convertAndSend(
-                    Constants.exchange,
+            sender.send(
                     Constants.RoutingKeys.hello,
                     "Bildungsportal"
             )

--- a/backend/src/main/kotlin/com/smartcity/education/backend/TestJwtConfig.kt
+++ b/backend/src/main/kotlin/com/smartcity/education/backend/TestJwtConfig.kt
@@ -1,0 +1,22 @@
+package com.smartcity.education.backend
+
+import com.smartcity.education.backend.authentication.TokenVerifier
+import org.springframework.amqp.rabbit.annotation.EnableRabbit
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableRabbit
+class TestJwtConfig {
+    @Bean
+    fun verifier(): TokenVerifier {
+        val verifier = TokenVerifier()
+        verifier.setSecret(System.getenv("JWT_SECRET"))
+        return verifier
+    }
+
+    @Bean
+    fun messageSender(): MessageSender {
+        return MessageSender { _, _ ->  }
+    }
+}

--- a/backend/src/main/kotlin/com/smartcity/education/backend/controllers/EducationApiController.kt
+++ b/backend/src/main/kotlin/com/smartcity/education/backend/controllers/EducationApiController.kt
@@ -1,6 +1,7 @@
 package com.smartcity.education.backend.controllers
 
 import com.smartcity.education.backend.Constants
+import com.smartcity.education.backend.MessageSender
 import com.smartcity.education.backend.assigners.Assigner
 import com.smartcity.education.backend.authentication.AuthUtil
 import com.smartcity.education.backend.models.Assessment
@@ -10,7 +11,6 @@ import com.smartcity.education.backend.models.Matriculation
 import com.smartcity.education.backend.repositories.EducationRepository
 import com.smartcity.education.backend.repositories.QualificationRepository
 import com.smartcity.education.backend.repositories.StudentRepository
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -30,7 +30,7 @@ class EducationApiController(
         private val studentRepository: StudentRepository,
         private val assigner: Assigner<EducationProperties, Education>,
         private val authUtil: AuthUtil,
-        private val template: RabbitTemplate
+        private val sender: MessageSender
 ) {
 
     @RequestMapping(
@@ -183,8 +183,7 @@ class EducationApiController(
             val created = repository.save(it)
 
             created.matriculations.last().id?.let { id ->
-                template.convertAndSend(
-                        Constants.exchange,
+                sender.send(
                         Constants.RoutingKeys.matriculated,
                         id.toString()
                 )

--- a/backend/src/main/kotlin/com/smartcity/education/backend/controllers/LocationApiController.kt
+++ b/backend/src/main/kotlin/com/smartcity/education/backend/controllers/LocationApiController.kt
@@ -1,13 +1,13 @@
 package com.smartcity.education.backend.controllers
 
 import com.smartcity.education.backend.Constants
+import com.smartcity.education.backend.MessageSender
 import com.smartcity.education.backend.assigners.LocationAssigner
 import com.smartcity.education.backend.authentication.AuthUtil
 import com.smartcity.education.backend.models.Education
 import com.smartcity.education.backend.models.Location
 import com.smartcity.education.backend.models.LocationProperties
 import com.smartcity.education.backend.repositories.LocationRepository
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -23,7 +23,7 @@ import javax.validation.Valid
 class LocationApiController(
         private val repository: LocationRepository,
         private val assigner: LocationAssigner,
-        private val template: RabbitTemplate,
+        private val sender: MessageSender,
         private val authUtil: AuthUtil
 ) {
     @RequestMapping(
@@ -68,8 +68,7 @@ class LocationApiController(
             val created = repository.save(it)
 
             created.educations.last().id?.let { id ->
-                template.convertAndSend(
-                        Constants.exchange,
+                sender.send(
                         Constants.RoutingKeys.created,
                         id.toString()
                 )

--- a/backend/src/test/kotlin/com/smartcity/education/backend/controllers/EducationApiControllerTests.kt
+++ b/backend/src/test/kotlin/com/smartcity/education/backend/controllers/EducationApiControllerTests.kt
@@ -1,6 +1,6 @@
 package com.smartcity.education.backend.controllers
 
-import com.smartcity.education.backend.Constants
+import com.smartcity.education.backend.MessageSender
 import com.smartcity.education.backend.assigners.EducationAssigner
 import com.smartcity.education.backend.authentication.AuthUtil
 import com.smartcity.education.backend.models.*
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.Mockito.*
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -33,7 +32,7 @@ class EducationApiControllerTests {
     @MockBean
     private val assigner: EducationAssigner? = null
     @MockBean
-    private val template: RabbitTemplate? = null
+    private val sender: MessageSender? = null
     @Autowired
     private val sut: EducationApiController? = null
 

--- a/backend/src/test/kotlin/com/smartcity/education/backend/controllers/LocationApiControllerTests.kt
+++ b/backend/src/test/kotlin/com/smartcity/education/backend/controllers/LocationApiControllerTests.kt
@@ -1,17 +1,16 @@
 package com.smartcity.education.backend.controllers
 
 import com.smartcity.education.backend.Constants
+import com.smartcity.education.backend.MessageSender
 import com.smartcity.education.backend.assigners.LocationAssigner
 import com.smartcity.education.backend.authentication.AuthUtil
 import com.smartcity.education.backend.models.Education
-import com.smartcity.education.backend.models.InstitutionProperties
 import com.smartcity.education.backend.models.Location
 import com.smartcity.education.backend.models.LocationProperties
 import com.smartcity.education.backend.repositories.LocationRepository
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -28,7 +27,7 @@ class LocationApiControllerTests {
     private val assigner: LocationAssigner? = null
 
     @MockBean
-    private val template: RabbitTemplate? = null
+    private val sender: MessageSender? = null
 
     @MockBean
     private val authUtil: AuthUtil? = null
@@ -111,8 +110,7 @@ class LocationApiControllerTests {
 
         verify(repository, times(1))?.findById(id)
         verify(repository, times(1))?.save(obj)
-        verify(template, times(1))?.convertAndSend(
-            Constants.exchange,
+        verify(sender, times(1))?.send(
             Constants.RoutingKeys.created,
             educationId.toString()
         )
@@ -142,8 +140,7 @@ class LocationApiControllerTests {
 
         verify(repository, times(1))?.findById(id)
         verify(repository, never())?.save(obj)
-        verify(template, never())?.convertAndSend(
-                Constants.exchange,
+        verify(sender, never())?.send(
                 Constants.RoutingKeys.created,
                 educationId.toString()
         )

--- a/backend/src/test/kotlin/com/smartcity/education/backend/controllers/MatriculationApiControllerTests.kt
+++ b/backend/src/test/kotlin/com/smartcity/education/backend/controllers/MatriculationApiControllerTests.kt
@@ -1,15 +1,17 @@
 package com.smartcity.education.backend.controllers
 
-import com.smartcity.education.backend.Constants
+import com.smartcity.education.backend.MessageSender
 import com.smartcity.education.backend.assigners.MatriculationAssigner
 import com.smartcity.education.backend.authentication.AuthUtil
-import com.smartcity.education.backend.models.*
+import com.smartcity.education.backend.models.Grade
+import com.smartcity.education.backend.models.Graduation
+import com.smartcity.education.backend.models.Matriculation
+import com.smartcity.education.backend.models.MatriculationProperties
 import com.smartcity.education.backend.repositories.AssessmentRepository
 import com.smartcity.education.backend.repositories.MatriculationRepository
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
-import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -29,7 +31,7 @@ class MatriculationApiControllerTests {
     @MockBean
     private val authUtil: AuthUtil? = null
     @MockBean
-    private val template: RabbitTemplate? = null
+    private val sender: MessageSender? = null
     @Autowired
     private val sut: MatriculationApiController? = null
 


### PR DESCRIPTION
Closes #76 

:warning: Auch in den Integrationstests muss die Umgebungsvariable `RABBITMQ_PORT` angegeben werden, da versucht wird diese Variable in einen Integer zu konvertieren, was fehlschlägt wenn die Variable leer ist. Auf den angegebenen Port wird **NICHT** zugegriffen. Die anderen `RABBITMQ` Umgebungsvariablen können leer sein.

:warning: Um das Backend ohne die Abhängigkeit auf RabbitMQ zu builden muss `-PisIntegrationTest=true` als Parameter beim Aufruf von Gradle angegeben werden. Also bspw. `./gradlew bootRun -PisIntegrationTest=true`